### PR TITLE
Update python upload data package example notebook

### DIFF
--- a/python_examples/upload_package.ipynb
+++ b/python_examples/upload_package.ipynb
@@ -1,31 +1,55 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Upload a data package\n",
+    "\n",
+    "This notebook will help you understand the basics of creating a data package with a few files and simple annotation using the DataONE Python client."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating initial package....\n",
-      "Created package with pid a8568980-170f-4a4c-b93e-3829e57dfe36\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import uuid\n",
-    "import hashlib\n",
     "import datetime\n",
+    "import hashlib\n",
     "import io\n",
+    "import itertools\n",
+    "import os\n",
+    "import uuid\n",
+    "import xml.dom.minidom\n",
+    "from pathlib import Path\n",
+    "from typing import Optional\n",
     "\n",
-    "from d1_client.mnclient_2_0 import *\n",
+    "import d1_common.const\n",
+    "from d1_client.mnclient_2_0 import MemberNodeClient_2_0\n",
     "from d1_common.types import dataoneTypes\n",
-    "from d1_common.resource_map import createSimpleResourceMap\n",
+    "from d1_common.resource_map import createSimpleResourceMap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def flatten_filepath(path: os.PathLike):\n",
+    "    \"\"\"Replace directory separators with double underscores.\"\"\"\n",
+    "    return str(path).replace(os.path.sep, '__')\n",
     "\n",
     "\n",
-    "def generate_system_metadata(pid: str, format_id: str, science_object: bytes, orcid: str):\n",
+    "def pretty_format_xml(x):\n",
+    "    dom = xml.dom.minidom.parseString(x)\n",
+    "    return dom.toprettyxml()\n",
+    "\n",
+    "\n",
+    "def generate_system_metadata(\n",
+    "    pid: str, format_id: str, science_object: bytes, orcid: str, filename: Optional[str] = None\n",
+    "):\n",
     "    \"\"\"\n",
     "    Generates a system metadata document.\n",
     "    :param pid: The pid that the object will have\n",
@@ -39,39 +63,28 @@
     "        if isinstance(science_object, str):\n",
     "            science_object = science_object.encode(\"utf-8\")\n",
     "        else:\n",
-    "            raise ValueError('Supplied science_object is not unicode')\n",
+    "            raise ValueError(\"Supplied science_object is not unicode\")\n",
     "\n",
     "    size = len(science_object)\n",
     "    md5 = hashlib.md5()\n",
     "    md5.update(science_object)\n",
     "    md5 = md5.hexdigest()\n",
     "    now = datetime.datetime.now()\n",
-    "    sys_meta = generate_sys_meta(pid, format_id, size, md5, now, orcid)\n",
-    "    return sys_meta\n",
-    "\n",
-    "\n",
-    "def generate_sys_meta(pid: str, format_id: str, size: int, md5, now, orcid: str):\n",
-    "    \"\"\"\n",
-    "    Fills out the system metadata object with the needed properties\n",
-    "    :param pid: The pid of the system metadata document\n",
-    "    :param format_id: The format of the document being described\n",
-    "    :param size: The size of the document that is being described\n",
-    "    :param md5: The md5 hash of the document being described\n",
-    "    :param now: The current time\n",
-    "    :param orcid: The uploader's orcid\n",
-    "    \"\"\"\n",
     "\n",
     "    sys_meta = dataoneTypes.systemMetadata()\n",
     "    sys_meta.identifier = str(pid)\n",
     "    sys_meta.formatId = format_id\n",
     "    sys_meta.size = size\n",
     "    sys_meta.rightsHolder = orcid\n",
-    "\n",
+    "    if filename:\n",
+    "        sys_meta.fileName = filename\n",
+    "    \n",
     "    sys_meta.checksum = dataoneTypes.checksum(str(md5))\n",
-    "    sys_meta.checksum.algorithm = 'MD5'\n",
+    "    sys_meta.checksum.algorithm = \"MD5\"\n",
     "    sys_meta.dateUploaded = now\n",
     "    sys_meta.dateSysMetadataModified = now\n",
     "    sys_meta.accessPolicy = generate_public_access_policy()\n",
+    "    \n",
     "    return sys_meta\n",
     "\n",
     "\n",
@@ -83,13 +96,13 @@
     "    accessPolicy = dataoneTypes.accessPolicy()\n",
     "    accessRule = dataoneTypes.AccessRule()\n",
     "    accessRule.subject.append(d1_common.const.SUBJECT_PUBLIC)\n",
-    "    permission = dataoneTypes.Permission('read')\n",
+    "    permission = dataoneTypes.Permission(\"read\")\n",
     "    accessRule.permission.append(permission)\n",
     "    accessPolicy.append(accessRule)\n",
     "    return accessPolicy\n",
     "\n",
     "\n",
-    "def create_minimum_eml() -> bytes:\n",
+    "def create_minimum_eml(title: str) -> bytes:\n",
     "    \"\"\"\n",
     "    Ugly method that creates a bare minimum EML record for a package.\n",
     "    This includes the title, creator, and contact. Ideally the EML shouldn't need\n",
@@ -103,72 +116,579 @@
     "    top = '<?xml version=\"1.0\" encoding=\"UTF-8\"?>'\n",
     "    namespace = '<eml:eml xmlns:eml=\"eml://ecoinformatics.org/eml-2.1.1\" xmlns:stmml=\"http://www.xml-cml.org/schema/stmml-1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" packageId=\"test_pkg\" system=\"test_system\" xsi:schemaLocation=\"eml://ecoinformatics.org/eml-2.1.1 eml.xsd\">'\n",
     "\n",
-    "    dataset = '<dataset>\\n'\n",
-    "    title = '<title>{0}</title>\\n'.format(\"Test Data Package\")\n",
+    "    dataset = \"<dataset>\"\n",
     "\n",
     "    # The uploader's surname\n",
-    "    individualName = '<individualName>\\n<surName>\\n{0}\\n</surName>\\n</individualName>'.format(\"Test User\")\n",
+    "    individualName = \"<individualName><surName>Test user</surName></individualName>\"\n",
     "\n",
     "    # Create an EML creator record\n",
-    "    creator = '<creator>\\n{0}\\n</creator>\\n'.format(individualName)\n",
+    "    creator = f\"<creator>{individualName}</creator>\"\n",
+    "\n",
     "    # Create an EML contact record\n",
-    "    contact = '<contact>\\n{0}\\n</contact>\\n'.format(individualName)\n",
-    "    dataset_close = '</dataset>\\n'\n",
-    "    eml_close = '</eml:eml>'\n",
+    "    contact = f\"<contact>{individualName}</contact>\"\n",
+    "    dataset_close = \"</dataset>\"\n",
+    "    eml_close = \"</eml:eml>\"\n",
     "\n",
     "    # Append the above xml strings together to form the EML document\n",
-    "    xml = top + namespace + dataset + title + creator + contact + dataset_close + eml_close\n",
+    "    xml = (\n",
+    "        top\n",
+    "        + namespace\n",
+    "        + dataset\n",
+    "        + f\"<title>{title}</title>\"\n",
+    "        + creator\n",
+    "        + contact\n",
+    "        + dataset_close\n",
+    "        + eml_close\n",
+    "    )\n",
     "\n",
-    "    return xml.encode(\"utf-8\")\n",
+    "    return xml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create test assets\n",
     "\n",
-    "def create_package(orcid):\n",
-    "\n",
-    "    # Create and upload the EML\n",
-    "    eml_pid = str(uuid.uuid4())\n",
-    "    eml_bytes = create_minimum_eml()\n",
-    "    meta_sm = generate_system_metadata(pid=eml_pid,\n",
-    "                                       format_id='eml://ecoinformatics.org/eml-2.1.1',\n",
-    "                                       science_object=eml_bytes,\n",
-    "                                       orcid=orcid)\n",
-    "    client.create(eml_pid, eml_bytes, meta_sm)\n",
-    "\n",
-    "    # Create and upload the data\n",
-    "    data = \"data\"\n",
-    "    data_pid = str(uuid.uuid4())\n",
-    "    data_bytes = data.encode('utf-8')\n",
-    "    data_sm = generate_system_metadata(pid=data_pid,\n",
-    "                                       format_id='text/plain',\n",
-    "                                       science_object=data_bytes,\n",
-    "                                       orcid=orcid)\n",
-    "    client.create(data_pid, data_bytes, data_sm)\n",
-    "\n",
-    "    # Create and upload the resource map\n",
-    "    ore_pid = str(uuid.uuid4())\n",
-    "    ore = createSimpleResourceMap(ore_pid, eml_pid, [data_pid])\n",
-    "    ore_meta = generate_system_metadata(pid=ore_pid,\n",
-    "                                        format_id='http://www.openarchives.org/ore/terms',\n",
-    "                                        science_object=ore.serialize(),\n",
-    "                                        orcid=orcid)\n",
-    "    client.create(ore_pid, ore.serialize(), ore_meta)\n",
-    "    return eml_pid\n",
+    "Generate a few small data files to include in your data package.\n",
     "\n",
     "\n",
-    "if __name__ == \"__main__\":\n",
-    "    \"\"\"\n",
-    "        Paste your auth token into 'auth_token' and your orcid into 'orcid'\n",
-    "    \"\"\"\n",
-    "    auth_token: str = \"\"\n",
-    "    # Set the token in the request header\n",
-    "    options: dict = {\"headers\": {\"Authorization\": \"Bearer \" + auth_token}}\n",
-    "    # Create the Member Node Client\n",
-    "    client: MemberNodeClient_2_0 = MemberNodeClient_2_0('https://dev.nceas.ucsb.edu/knb/d1/mn/', **options)\n",
-    "    # Set your ORCID\n",
-    "    orcid: str = \"http://orcid.org/0000-0002-1756-2128\"\n",
+    "```\n",
+    "tmp1\n",
+    "├── file1.txt\n",
+    "└── file2.txt\n",
+    "tmp2\n",
+    "├── file1.txt\n",
+    "└── file2.txt\n",
+    "```\n",
     "\n",
-    "    # Create & upload a default package to dataone\n",
-    "    print(\"Creating initial package....\")\n",
-    "    eml_pid = create_package(orcid)\n",
-    "    print(\"Created package with pid {}\".format(eml_pid))"
+    "Note that since a data package cannot represent a directory hierarchy, we will use `flatten_filepath` to \"flatten\" each path, i.e., `tmp1/file1.txt` becomes `tmp1__file1.txt`.\n",
+    "\n",
+    "We also include the format of each file. In this case, the data are all text files with the format `text/plain`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'path': PosixPath('tmp1/file1.txt'), 'format': 'text/plain'},\n",
+       " {'path': PosixPath('tmp1/file2.txt'), 'format': 'text/plain'},\n",
+       " {'path': PosixPath('tmp2/file1.txt'), 'format': 'text/plain'},\n",
+       " {'path': PosixPath('tmp2/file2.txt'), 'format': 'text/plain'}]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for directory_name in (\"tmp1\", \"tmp2\"):\n",
+    "    (directory := Path(directory_name)).mkdir(exist_ok=True)\n",
+    "    for filename in (\"file1.txt\", \"file2.txt\"):\n",
+    "        (directory / filename).write_text(f\"This is {filename} in directory {directory_name}\")\n",
+    "\n",
+    "files = [\n",
+    "    {'path': path, 'format': 'text/plain'} for path in sorted(itertools.chain(Path('tmp1').rglob('*'), Path('tmp2').rglob('*')))\n",
+    "    \n",
+    "]\n",
+    "\n",
+    "files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create the data package\n",
+    "\n",
+    "First, replace the following variable values:\n",
+    "\n",
+    "- `orcid`\n",
+    "- `auth_token`: Your [JWT](https://jwt.io/) that you get from your DataONE profile page\n",
+    "\n",
+    "By default this notebook will generate a data package title \"Test data package \\<abc\\>\" where `<abc>` will be a random suffix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set your ORCID\n",
+    "orcid: str = \"http://orcid.org/0000-0002-1756-2128\"\n",
+    "\n",
+    "# Provide an authentication token\n",
+    "auth_token: str = \"\"\n",
+    "\n",
+    "# Set the token in the request header\n",
+    "options: dict = {\"headers\": {\"Authorization\": \"Bearer \" + auth_token}}\n",
+    "\n",
+    "# Create the Member Node Client\n",
+    "client: MemberNodeClient_2_0 = MemberNodeClient_2_0(\"https://dev.nceas.ucsb.edu/knb/d1/mn\", **options)\n",
+    "\n",
+    "title: str = f\"\"\"Test data package {\"\".join(uuid.uuid4().hex[:8])}\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create and upload the EML"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating EML with PID 1efeefaa-5c67-4b1e-a384-639ceac512a9\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<d1_common.types.generated.dataoneTypes_v1.Identifier at 0x7fdb01971450>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "eml_pid = str(uuid.uuid4())\n",
+    "eml = create_minimum_eml(title)\n",
+    "eml_bytes = eml.encode(\"utf-8\")\n",
+    "meta_sm = generate_system_metadata(\n",
+    "    pid=eml_pid,\n",
+    "    format_id=\"eml://ecoinformatics.org/eml-2.1.1\",\n",
+    "    science_object=eml_bytes,\n",
+    "    orcid=orcid,\n",
+    ")\n",
+    "print(f\"Creating EML with PID {eml_pid}\")\n",
+    "client.create(eml_pid, eml_bytes, meta_sm)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's the science metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version=\"1.0\" ?>\n",
+      "<eml:eml xmlns:eml=\"eml://ecoinformatics.org/eml-2.1.1\" xmlns:stmml=\"http://www.xml-cml.org/schema/stmml-1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" packageId=\"test_pkg\" system=\"test_system\" xsi:schemaLocation=\"eml://ecoinformatics.org/eml-2.1.1 eml.xsd\">\n",
+      "\t<dataset>\n",
+      "\t\t<title>Test data package ba2943fb</title>\n",
+      "\t\t<creator>\n",
+      "\t\t\t<individualName>\n",
+      "\t\t\t\t<surName>Test user</surName>\n",
+      "\t\t\t</individualName>\n",
+      "\t\t</creator>\n",
+      "\t\t<contact>\n",
+      "\t\t\t<individualName>\n",
+      "\t\t\t\t<surName>Test user</surName>\n",
+      "\t\t\t</individualName>\n",
+      "\t\t</contact>\n",
+      "\t</dataset>\n",
+      "</eml:eml>\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(pretty_format_xml(eml))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And the system metadata for that science metadata:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version=\"1.0\" ?>\n",
+      "<ns1:systemMetadata xmlns:ns1=\"http://ns.dataone.org/service/types/v2.0\">\n",
+      "\t<identifier>1efeefaa-5c67-4b1e-a384-639ceac512a9</identifier>\n",
+      "\t<formatId>eml://ecoinformatics.org/eml-2.1.1</formatId>\n",
+      "\t<size>538</size>\n",
+      "\t<checksum algorithm=\"MD5\">769f24d6149c3f22316522c437dd5fd6</checksum>\n",
+      "\t<rightsHolder>http://orcid.org/0000-0002-2661-8912</rightsHolder>\n",
+      "\t<accessPolicy>\n",
+      "\t\t<allow>\n",
+      "\t\t\t<subject>public</subject>\n",
+      "\t\t\t<permission>read</permission>\n",
+      "\t\t</allow>\n",
+      "\t</accessPolicy>\n",
+      "\t<dateUploaded>2025-01-24T17:06:09.677176</dateUploaded>\n",
+      "\t<dateSysMetadataModified>2025-01-24T17:06:09.677176</dateSysMetadataModified>\n",
+      "</ns1:systemMetadata>\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(pretty_format_xml(meta_sm.toxml()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create and upload the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating data tmp1/file1.txt with PID 66d34b2dfd79419bbf2fc6f7b2e77f7b\n",
+      "Creating data tmp1/file2.txt with PID b9bcab58d28445618a4f67af8dcc16e3\n",
+      "Creating data tmp2/file1.txt with PID 722b7d2245bd49459e18b8f56ce63f91\n",
+      "Creating data tmp2/file2.txt with PID ec091619cd82476b96a61f4431046754\n"
+     ]
+    }
+   ],
+   "source": [
+    "data_pids = []\n",
+    "for data in files:\n",
+    "    data_pid = uuid.uuid4().hex\n",
+    "    data_pids.append(data_pid)\n",
+    "    with Path(data[\"path\"]).open(\"rb\") as fp:\n",
+    "        data_bytes = fp.read()\n",
+    "    data_sm = generate_system_metadata(\n",
+    "        pid=data_pid,\n",
+    "        format_id=data[\"format\"],\n",
+    "        science_object=data_bytes,\n",
+    "        orcid=orcid,\n",
+    "        filename=flatten_filepath(data[\"path\"])\n",
+    "    )\n",
+    "    print(f\"\"\"Creating data {data[\"path\"]} with PID {data_pid}\"\"\")\n",
+    "    client.create(data_pid, data_bytes, data_sm)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the last file's system metadata as an example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version=\"1.0\" ?>\n",
+      "<ns1:systemMetadata xmlns:ns1=\"http://ns.dataone.org/service/types/v2.0\">\n",
+      "\t<identifier>ec091619cd82476b96a61f4431046754</identifier>\n",
+      "\t<formatId>text/plain</formatId>\n",
+      "\t<size>35</size>\n",
+      "\t<checksum algorithm=\"MD5\">ca6101b8d25b3266271b9fa2d1892a3d</checksum>\n",
+      "\t<rightsHolder>http://orcid.org/0000-0002-2661-8912</rightsHolder>\n",
+      "\t<accessPolicy>\n",
+      "\t\t<allow>\n",
+      "\t\t\t<subject>public</subject>\n",
+      "\t\t\t<permission>read</permission>\n",
+      "\t\t</allow>\n",
+      "\t</accessPolicy>\n",
+      "\t<dateUploaded>2025-01-24T17:06:13.536165</dateUploaded>\n",
+      "\t<dateSysMetadataModified>2025-01-24T17:06:13.536165</dateSysMetadataModified>\n",
+      "\t<fileName>tmp2__file2.txt</fileName>\n",
+      "</ns1:systemMetadata>\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(pretty_format_xml(data_sm.toxml()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create and upload the resource map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating resource map with PID dac060d6-cb9e-48bd-b587-d84c0fe5758d\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<d1_common.types.generated.dataoneTypes_v1.Identifier at 0x7fdb017eae40>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ore_pid = str(uuid.uuid4())\n",
+    "ore = createSimpleResourceMap(ore_pid, eml_pid, data_pids)\n",
+    "ore_meta = generate_system_metadata(\n",
+    "    pid=ore_pid,\n",
+    "    format_id=\"http://www.openarchives.org/ore/terms\",\n",
+    "    science_object=ore.serialize(format=\"xml\"),\n",
+    "    orcid=orcid,\n",
+    ")\n",
+    "print(f\"Creating resource map with PID {ore_pid}\")\n",
+    "client.create(ore_pid, ore.serialize(format=\"xml\"), ore_meta)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's the resource map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version=\"1.0\" ?>\n",
+      "<rdf:RDF xmlns:cito=\"http://purl.org/spar/cito/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" xmlns:ore=\"http://www.openarchives.org/ore/terms/\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\">\n",
+      "\t\n",
+      "  \n",
+      "\t<rdf:Description rdf:about=\"https://cn.dataone.org/cn/v2/resolve/1efeefaa-5c67-4b1e-a384-639ceac512a9\">\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<ore:isAggregatedBy rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/dac060d6-cb9e-48bd-b587-d84c0fe5758d#aggregation\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<dcterms:identifier>1efeefaa-5c67-4b1e-a384-639ceac512a9</dcterms:identifier>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<cito:documents rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/66d34b2dfd79419bbf2fc6f7b2e77f7b\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<cito:documents rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/b9bcab58d28445618a4f67af8dcc16e3\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<cito:documents rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/722b7d2245bd49459e18b8f56ce63f91\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<cito:documents rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/ec091619cd82476b96a61f4431046754\"/>\n",
+      "\t\t\n",
+      "  \n",
+      "\t</rdf:Description>\n",
+      "\t\n",
+      "  \n",
+      "\t<rdf:Description rdf:about=\"https://cn.dataone.org/cn/v2/resolve/dac060d6-cb9e-48bd-b587-d84c0fe5758d\">\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<rdf:type rdf:resource=\"http://www.openarchives.org/ore/terms/ResourceMap\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<dcterms:identifier>dac060d6-cb9e-48bd-b587-d84c0fe5758d</dcterms:identifier>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<dcterms:creator>DataONE.org Python ITK 3.5.2</dcterms:creator>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<ore:describes rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/dac060d6-cb9e-48bd-b587-d84c0fe5758d#aggregation\"/>\n",
+      "\t\t\n",
+      "  \n",
+      "\t</rdf:Description>\n",
+      "\t\n",
+      "  \n",
+      "\t<rdf:Description rdf:about=\"https://cn.dataone.org/cn/v2/resolve/66d34b2dfd79419bbf2fc6f7b2e77f7b\">\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<ore:isAggregatedBy rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/dac060d6-cb9e-48bd-b587-d84c0fe5758d#aggregation\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<dcterms:identifier>66d34b2dfd79419bbf2fc6f7b2e77f7b</dcterms:identifier>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<cito:isDocumentedBy rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/1efeefaa-5c67-4b1e-a384-639ceac512a9\"/>\n",
+      "\t\t\n",
+      "  \n",
+      "\t</rdf:Description>\n",
+      "\t\n",
+      "  \n",
+      "\t<rdf:Description rdf:about=\"https://cn.dataone.org/cn/v2/resolve/722b7d2245bd49459e18b8f56ce63f91\">\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<ore:isAggregatedBy rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/dac060d6-cb9e-48bd-b587-d84c0fe5758d#aggregation\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<dcterms:identifier>722b7d2245bd49459e18b8f56ce63f91</dcterms:identifier>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<cito:isDocumentedBy rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/1efeefaa-5c67-4b1e-a384-639ceac512a9\"/>\n",
+      "\t\t\n",
+      "  \n",
+      "\t</rdf:Description>\n",
+      "\t\n",
+      "  \n",
+      "\t<rdf:Description rdf:about=\"http://www.openarchives.org/ore/terms/Aggregation\">\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<rdfs:isDefinedBy rdf:resource=\"http://www.openarchives.org/ore/terms/\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<rdfs:label>Aggregation</rdfs:label>\n",
+      "\t\t\n",
+      "  \n",
+      "\t</rdf:Description>\n",
+      "\t\n",
+      "  \n",
+      "\t<rdf:Description rdf:about=\"https://cn.dataone.org/cn/v2/resolve/ec091619cd82476b96a61f4431046754\">\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<ore:isAggregatedBy rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/dac060d6-cb9e-48bd-b587-d84c0fe5758d#aggregation\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<dcterms:identifier>ec091619cd82476b96a61f4431046754</dcterms:identifier>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<cito:isDocumentedBy rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/1efeefaa-5c67-4b1e-a384-639ceac512a9\"/>\n",
+      "\t\t\n",
+      "  \n",
+      "\t</rdf:Description>\n",
+      "\t\n",
+      "  \n",
+      "\t<rdf:Description rdf:about=\"https://cn.dataone.org/cn/v2/resolve/dac060d6-cb9e-48bd-b587-d84c0fe5758d#aggregation\">\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<rdf:type rdf:resource=\"http://www.openarchives.org/ore/terms/Aggregation\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<ore:aggregates rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/1efeefaa-5c67-4b1e-a384-639ceac512a9\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<ore:aggregates rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/66d34b2dfd79419bbf2fc6f7b2e77f7b\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<ore:aggregates rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/b9bcab58d28445618a4f67af8dcc16e3\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<ore:aggregates rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/722b7d2245bd49459e18b8f56ce63f91\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<ore:aggregates rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/ec091619cd82476b96a61f4431046754\"/>\n",
+      "\t\t\n",
+      "  \n",
+      "\t</rdf:Description>\n",
+      "\t\n",
+      "  \n",
+      "\t<rdf:Description rdf:about=\"https://cn.dataone.org/cn/v2/resolve/b9bcab58d28445618a4f67af8dcc16e3\">\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<ore:isAggregatedBy rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/dac060d6-cb9e-48bd-b587-d84c0fe5758d#aggregation\"/>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<dcterms:identifier>b9bcab58d28445618a4f67af8dcc16e3</dcterms:identifier>\n",
+      "\t\t\n",
+      "    \n",
+      "\t\t<cito:isDocumentedBy rdf:resource=\"https://cn.dataone.org/cn/v2/resolve/1efeefaa-5c67-4b1e-a384-639ceac512a9\"/>\n",
+      "\t\t\n",
+      "  \n",
+      "\t</rdf:Description>\n",
+      "\t\n",
+      "\n",
+      "</rdf:RDF>\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(pretty_format_xml(ore.serialize(format=\"xml\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And the resource map system metadata:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<?xml version=\"1.0\" ?>\n",
+      "<ns1:systemMetadata xmlns:ns1=\"http://ns.dataone.org/service/types/v2.0\">\n",
+      "\t<identifier>dac060d6-cb9e-48bd-b587-d84c0fe5758d</identifier>\n",
+      "\t<formatId>http://www.openarchives.org/ore/terms</formatId>\n",
+      "\t<size>4317</size>\n",
+      "\t<checksum algorithm=\"MD5\">0fcf2a4759669df3f9739c0d78e9c1ff</checksum>\n",
+      "\t<rightsHolder>http://orcid.org/0000-0002-2661-8912</rightsHolder>\n",
+      "\t<accessPolicy>\n",
+      "\t\t<allow>\n",
+      "\t\t\t<subject>public</subject>\n",
+      "\t\t\t<permission>read</permission>\n",
+      "\t\t</allow>\n",
+      "\t</accessPolicy>\n",
+      "\t<dateUploaded>2025-01-24T17:06:14.700613</dateUploaded>\n",
+      "\t<dateSysMetadataModified>2025-01-24T17:06:14.700613</dateSysMetadataModified>\n",
+      "</ns1:systemMetadata>\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(pretty_format_xml(ore_meta.toxml()))"
    ]
   },
   {
@@ -181,7 +701,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -195,9 +715,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Updates to the Python example notebok:
- Fix the notebook (based on @iannesbitt 's advice) rdflib changed the default serialization format to turtle, which the DataONE indexer does not support. Specify the format as xml when serializing.
- Extend the example a bit to demonstrate uploading files and adding the file name metadata
- Break open some of the larger functions to demonstrate how they work a bit more (for the newbies like me)